### PR TITLE
ci: test on PR but do not publish

### DIFF
--- a/.github/workflows/doc_html.yml
+++ b/.github/workflows/doc_html.yml
@@ -1,8 +1,7 @@
 name: 'Documentation HTML'
 on:
   push:
-    branches:
-      - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -34,7 +33,8 @@ jobs:
           teroshdl_doc
 
     - name: Deploy 🚀
+      if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/'))
       uses: JamesIves/github-pages-deploy-action@4.1.4
       with:
-        branch: gh-pages 
-        folder: teroshdl_doc 
+        branch: gh-pages
+        folder: teroshdl_doc

--- a/.github/workflows/doc_markdown.yml
+++ b/.github/workflows/doc_markdown.yml
@@ -1,8 +1,7 @@
 name: 'Documentation Markdown'
 on:
   push:
-    branches:
-      - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -34,7 +33,8 @@ jobs:
           teroshdl_doc
 
     - name: Deploy 🚀
+      if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/'))
       uses: JamesIves/github-pages-deploy-action@4.1.4
       with:
         branch: documentation-markdown
-        folder: teroshdl_doc 
+        folder: teroshdl_doc


### PR DESCRIPTION
This allows the workflow to be executed on PRs and branches other than `main`, but avoids pushing the results.