### PR TITLE
make generate_doc.py executable

### DIFF
--- a/.github/workflows/doc_html.yml
+++ b/.github/workflows/doc_html.yml
@@ -22,8 +22,7 @@ jobs:
         sudo npm install -g .
 
     - name: 'Generate documentation HTML'
-      run: |
-        python3 generate_doc.py html
+      run: ./generate_doc.py html
 
     - name: '📤 Upload artifact: HTML'
       uses: actions/upload-artifact@master

--- a/.github/workflows/doc_html.yml
+++ b/.github/workflows/doc_html.yml
@@ -14,24 +14,23 @@ jobs:
     - name: '🧰 Checkout'
       uses: actions/checkout@v2
 
-    - name: '📓 Install TerosHDL and VUnit'
+    - name: '⚙️ Install TerosHDL and VUnit'
       run: |
         sudo pip3 install vunit_hdl
         git clone https://github.com/TerosTechnology/colibri.git
         cd colibri
         sudo npm install -g .
 
-    - name: 'Generate documentation HTML'
+    - name: '📓 Generate documentation HTML'
       run: ./generate_doc.py html
 
     - name: '📤 Upload artifact: HTML'
       uses: actions/upload-artifact@master
       with:
         name: documentation-html
-        path: |
-          teroshdl_doc
+        path: teroshdl_doc
 
-    - name: Deploy 🚀
+    - name: '🚀 Deploy'
       if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/'))
       uses: JamesIves/github-pages-deploy-action@4.1.4
       with:

--- a/.github/workflows/doc_html.yml
+++ b/.github/workflows/doc_html.yml
@@ -1,8 +1,7 @@
 name: 'Documentation HTML'
 on:
   push:
-    branches:
-      - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -34,7 +33,8 @@ jobs:
           teroshdl_doc
 
     - name: Deploy 🚀
+      if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/'))
       uses: JamesIves/github-pages-deploy-action@4.1.4
       with:
-        branch: gh-pages 
-        folder: teroshdl_doc 
+        branch: gh-pages
+        folder: teroshdl_doc

--- a/.github/workflows/doc_markdown.yml
+++ b/.github/workflows/doc_markdown.yml
@@ -22,8 +22,7 @@ jobs:
         sudo npm install -g .
 
     - name: 'Generate documentation Markdown'
-      run: |
-        python3 generate_doc.py markdown
+      run: ./generate_doc.py markdown
 
     - name: '📤 Upload artifact: Markdown'
       uses: actions/upload-artifact@master

--- a/.github/workflows/doc_markdown.yml
+++ b/.github/workflows/doc_markdown.yml
@@ -1,8 +1,7 @@
 name: 'Documentation Markdown'
 on:
   push:
-    branches:
-      - main
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -34,7 +33,8 @@ jobs:
           teroshdl_doc
 
     - name: Deploy 🚀
+      if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/'))
       uses: JamesIves/github-pages-deploy-action@4.1.4
       with:
         branch: documentation-markdown
-        folder: teroshdl_doc 
+        folder: teroshdl_doc

--- a/.github/workflows/doc_markdown.yml
+++ b/.github/workflows/doc_markdown.yml
@@ -14,24 +14,23 @@ jobs:
     - name: '🧰 Checkout'
       uses: actions/checkout@v2
 
-    - name: '📓 Install TerosHDL and VUnit'
+    - name: '⚙️ Install TerosHDL and VUnit'
       run: |
         sudo pip3 install vunit_hdl
         git clone https://github.com/TerosTechnology/colibri.git
         cd colibri
         sudo npm install -g .
 
-    - name: 'Generate documentation Markdown'
+    - name: '📓 Generate documentation Markdown'
       run: ./generate_doc.py markdown
 
     - name: '📤 Upload artifact: Markdown'
       uses: actions/upload-artifact@master
       with:
         name: documentation-markdown
-        path: |
-          teroshdl_doc
+        path: teroshdl_doc
 
-    - name: Deploy 🚀
+    - name: '🚀 Deploy'
       if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags/'))
       uses: JamesIves/github-pages-deploy-action@4.1.4
       with:

--- a/generate_doc.py
+++ b/generate_doc.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright 2021 Teros Technology
 #
 # Ismael Perez Rojo ismaelprojo@gmail.com


### PR DESCRIPTION
Close #1

This PR is based on #1.

`generate_doc.py` is made executable so that `./generate_doc.py` works instead of requiring `python generate_doc.py`.